### PR TITLE
fix(examples): update deprecated ami in tfvars

### DIFF
--- a/examples/net_vm/terraform.tfvars
+++ b/examples/net_vm/terraform.tfvars
@@ -2,7 +2,7 @@
 #secret_key_id       = "MySecretKey"
 #region              = "eu-west-2"
 
-image_id        = "ami-cdfcddb7" # Ubuntu-20.04-2021.02.10-5 on eu-west-2
+image_id        = "ami-19c942b5" # Ubuntu-20.04-2021.02.10-5 on eu-west-2
 vm_type         = "tinav4.c1r1p2"
 allowed_cidr    = ["0.0.0.0/0"]
 net_ip_range    = "10.0.0.0/16"

--- a/examples/public_load_balancer/terraform.tfvars
+++ b/examples/public_load_balancer/terraform.tfvars
@@ -2,6 +2,6 @@
 #secret_key_id       = "MySecretKey"
 #region              = "eu-west-2"
 
-image_id = "ami-cdfcddb7" # Ubuntu-20.04-2021.02.10-5 on eu-west-2
+image_id = "ami-19c942b5" # Ubuntu-20.04-2021.02.10-5 on eu-west-2
 vm_type  = "tinav4.c1r1p2"
 vm_count = 2

--- a/examples/public_vm/terraform.tfvars
+++ b/examples/public_vm/terraform.tfvars
@@ -5,6 +5,6 @@
 volume_type     = "io1"
 volume_iops     = 10000
 volume_size_gib = 200
-image_id        = "ami-cdfcddb7" # Ubuntu-20.04-2021.02.10-5 on eu-west-2
+image_id        = "ami-19c942b5" # Ubuntu-20.04-2021.02.10-5 on eu-west-2
 vm_type         = "tinav4.c1r1p2"
 allowed_cidr    = ["0.0.0.0/0"]


### PR DESCRIPTION
Hi, this is a quick PR to update the ami used in the examples, so that they work out of the box.