### PR TITLE
Update Github Action to test real code

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v2
+        with:
+            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: [self-hosted, linux]
     steps:
       - uses: actions/checkout@v2
+        with:
+            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            ref: ${{ github.event.pull_request.head.ref }}
       - name: Set up Go
         uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
Until now, the e2e tested the target branch (the branch that we want to push). This was not what we wanted to do.

With this fix, we DO test the code but we need to take care of credential leaking. We need to set up the repo to enforce approval of execution of GH Action from people outside of the organization (cf [doc](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)) 