### PR TITLE
remove exceded filter value

### DIFF
--- a/outscale/data_source_outscale_net_peerings_test.go
+++ b/outscale/data_source_outscale_net_peerings_test.go
@@ -52,7 +52,7 @@ const testAccDataSourceOutscaleOAPILinPeeringsConnectionConfig = `
 	data "outscale_net_peerings" "outscale_net_peerings" {
 		filter {
 			name   = "net_peering_ids"
-			values = ["${outscale_net_peering.outscale_net_peering.net_peering_id}", "${outscale_net_peering.outscale_net_peering2.net_peering_id}"]
+			values = ["${outscale_net_peering.outscale_net_peering.net_peering_id}"]
 		}
 	}
 `


### PR DESCRIPTION
too many filter values, the test expect 1 datasource but got 2

Signed-off-by: Thiery Ouattara <opensource@outscale.com>