### PR TITLE
check release before publish

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,6 +51,6 @@ signs:
       - "${artifact}"
 release:
   # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
+    draft: true
 changelog:
   skip: true


### PR DESCRIPTION
When pushing a new release tags, goreleaser will create automatically a draft release and we can manually publish or not 