### PR TITLE
Fix iprange test

### DIFF
--- a/outscale/data_source_outscale_client_gateway_test.go
+++ b/outscale/data_source_outscale_client_gateway_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleGatewayDatasource_basic(t *testing.T) {
 	t.Parallel()
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := utils.RandIntRange(64512, 65534)
 	value := fmt.Sprintf("testacc-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
@@ -27,7 +28,7 @@ func TestAccOutscaleGatewayDatasource_basic(t *testing.T) {
 func TestAccOutscaleGatewayDatasource_withFilters(t *testing.T) {
 	t.Parallel()
 	// datasourceName := "data.outscale_client_gateway.test"
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := utils.RandIntRange(64512, 65534)
 	value := fmt.Sprintf("testacc-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{

--- a/outscale/data_source_outscale_keypair_test.go
+++ b/outscale/data_source_outscale_keypair_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleOAPIKeypairDataSource_Instance(t *testing.T) {
 	t.Parallel()
-	keyPairName := fmt.Sprintf("acc-test-keypair-%d", acctest.RandIntRange(0, 400))
+	keyPairName := fmt.Sprintf("acc-test-keypair-%d", utils.RandIntRange(0, 400))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/outscale/data_source_outscale_keypairs_test.go
+++ b/outscale/data_source_outscale_keypairs_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleOAPIKeypairsDataSource_Instance(t *testing.T) {
 	t.Parallel()
-	keyPairName := fmt.Sprintf("testacc-keypair-%d", acctest.RandIntRange(0, 400))
+	keyPairName := fmt.Sprintf("testacc-keypair-%d", utils.RandIntRange(0, 400))
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/outscale/data_source_outscale_load_balancers_test.go
+++ b/outscale/data_source_outscale_load_balancers_test.go
@@ -5,15 +5,15 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleOAPIDSLBSU_basic(t *testing.T) {
 	t.Parallel()
 	region := os.Getenv("OUTSCALE_REGION")
 	zone := fmt.Sprintf("%sa", region)
-	numLbu := acctest.RandIntRange(0, 50)
+	numLbu := utils.RandIntRange(0, 50)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/outscale/data_source_outscale_net_test.go
+++ b/outscale/data_source_outscale_net_test.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccDataSourceOutscaleOAPIVpc_basic(t *testing.T) {
 	t.Parallel()
 	rand.Seed(time.Now().UTC().UnixNano())
-	rInt := rand.Intn(16)
-	ipRange := fmt.Sprintf("172.%d.0.0/16", rInt)
-	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-%d", rInt)
+	ipRange := utils.RandVpcCidr()
+	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-%s", ipRange)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -72,7 +72,6 @@ func testAccDataSourceOutscaleOAPIVpcConfig(ipRange, tag string) string {
 		}
 		
 		data "outscale_net" "by_id" {
-			#  net_id = "${outscale_net.test.id}"
 			filter {
 				name   = "net_ids"
 				values = ["${outscale_net.test.id}"]

--- a/outscale/data_source_outscale_nets_test.go
+++ b/outscale/data_source_outscale_nets_test.go
@@ -7,14 +7,14 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccDataSourceOutscaleOAPIVpcs_basic(t *testing.T) {
 
 	rand.Seed(time.Now().UTC().UnixNano())
-	rInt := rand.Intn(16)
-	ipRange := fmt.Sprintf("172.%d.0.0/16", rInt)
-	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-%d", rInt)
+	ipRange := utils.RandVpcCidr()
+	tag := fmt.Sprintf("terraform-testacc-vpc-data-source-%s", ipRange)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/outscale/data_source_outscale_subnets_test.go
+++ b/outscale/data_source_outscale_subnets_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccDataSourceOutscaleOAPISubnets(t *testing.T) {
 	t.Parallel()
-	rInt := acctest.RandIntRange(0, 256)
+	rInt := utils.RandIntRange(16, 31)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/outscale/data_source_outscale_vpn_connection_test.go
+++ b/outscale/data_source_outscale_vpn_connection_test.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleVPNConnectionDataSource_basic(t *testing.T) {
 	t.Parallel()
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -25,7 +26,7 @@ func TestAccOutscaleVPNConnectionDataSource_basic(t *testing.T) {
 
 func TestAccOutscaleVPNConnectionDataSource_withFilters(t *testing.T) {
 	t.Parallel()
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/outscale/data_source_outscale_vpn_connections_test.go
+++ b/outscale/data_source_outscale_vpn_connections_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleVPNConnectionsDataSource_basic(t *testing.T) {
 	t.Parallel()
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -25,7 +25,7 @@ func TestAccOutscaleVPNConnectionsDataSource_basic(t *testing.T) {
 
 func TestAccOutscaleVPNConnectionsDataSource_withFilters(t *testing.T) {
 	t.Parallel()
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/outscale/resource_outscale_client_gateway_test.go
+++ b/outscale/resource_outscale_client_gateway_test.go
@@ -17,8 +17,8 @@ import (
 func TestAccOutscaleClientGateway_basic(t *testing.T) {
 	t.Parallel()
 	resourceName := "outscale_client_gateway.foo"
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
-	rBgpAsnUpdated := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := utils.RandIntRange(64512, 65534)
+	rBgpAsnUpdated := utils.RandIntRange(64512, 65534)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },

--- a/outscale/resource_outscale_load_balancer_attributes_test.go
+++ b/outscale/resource_outscale_load_balancer_attributes_test.go
@@ -6,16 +6,16 @@ import (
 
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/terraform-providers/terraform-provider-outscale/utils"
 )
 
 func TestAccOutscaleOAPILBUAttr_basic(t *testing.T) {
 	t.Parallel()
 	var conf oscgo.AccessLog
 
-	r := acctest.RandIntRange(0, 10)
+	r := utils.RandIntRange(0, 10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/outscale/resource_outscale_load_balancer_test.go
+++ b/outscale/resource_outscale_load_balancer_test.go
@@ -11,7 +11,6 @@ import (
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -22,7 +21,7 @@ func TestAccOutscaleOAPILBUBasic(t *testing.T) {
 
 	resourceName := "outscale_load_balancer.bar"
 
-	r := acctest.RandIntRange(0, 50)
+	r := utils.RandIntRange(0, 50)
 	region := os.Getenv("OUTSCALE_REGION")
 	zone := fmt.Sprintf("%sa", region)
 
@@ -53,7 +52,7 @@ func TestAccOutscaleOAPILBUPublicIp(t *testing.T) {
 
 	resourceName := "outscale_load_balancer.bar"
 
-	r := acctest.RandIntRange(0, 50)
+	r := utils.RandIntRange(0, 50)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/outscale/resource_outscale_virtual_gateway_route_propagation_test.go
+++ b/outscale/resource_outscale_virtual_gateway_route_propagation_test.go
@@ -9,14 +9,13 @@ import (
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccOutscaleOAPIVirtualRoutePropagation_basic(t *testing.T) {
 	t.Parallel()
-	rBgpAsn := acctest.RandIntRange(64512, 65534)
+	rBgpAsn := utils.RandIntRange(64512, 65534)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {

--- a/outscale/resource_outscale_vpn_connection_route_test.go
+++ b/outscale/resource_outscale_vpn_connection_route_test.go
@@ -10,7 +10,6 @@ import (
 	oscgo "github.com/outscale/osc-sdk-go/v2"
 	"github.com/terraform-providers/terraform-provider-outscale/utils"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -19,8 +18,8 @@ func TestAccOutscaleVPNConnectionRoute_basic(t *testing.T) {
 	t.Parallel()
 	resourceName := "outscale_vpn_connection_route.foo"
 
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
-	destinationIPRange := fmt.Sprintf("172.168.%d.0/24", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
+	destinationIPRange := fmt.Sprintf("172.168.%d.0/24", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,8 +43,8 @@ func TestAccOutscaleVPNConnectionRouteimport_basic(t *testing.T) {
 	if os.Getenv("TEST_QUOTA") == "true" {
 		resourceName := "outscale_vpn_connection_route.foo"
 
-		publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
-		destinationIPRange := fmt.Sprintf("172.168.%d.0/24", acctest.RandIntRange(1, 255))
+		publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
+		destinationIPRange := fmt.Sprintf("172.168.%d.0/24", utils.RandIntRange(1, 255))
 
 		resource.Test(t, resource.TestCase{
 			PreCheck:     func() { testAccPreCheck(t) },

--- a/outscale/resource_outscale_vpn_connection_test.go
+++ b/outscale/resource_outscale_vpn_connection_test.go
@@ -18,7 +18,7 @@ func TestAccOutscaleVPNConnection_basic(t *testing.T) {
 	t.Parallel()
 	resourceName := "outscale_vpn_connection.foo"
 
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -73,7 +73,7 @@ func TestAccOutscaleVPNConnection_basic(t *testing.T) {
 func TestAccOutscaleVPNConnection_withoutStaticRoutes(t *testing.T) {
 	t.Parallel()
 	resourceName := "outscale_vpn_connection.foo"
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(0, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(0, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -100,7 +100,7 @@ func TestAccOutscaleVPNConnection_withTags(t *testing.T) {
 	t.Parallel()
 	resourceName := "outscale_vpn_connection.foo"
 
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 	value := fmt.Sprintf("testacc-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
@@ -132,7 +132,7 @@ func TestAccOutscaleVPNConnection_importBasic(t *testing.T) {
 	t.Parallel()
 	resourceName := "outscale_vpn_connection.foo"
 
-	publicIP := fmt.Sprintf("172.0.0.%d", acctest.RandIntRange(1, 255))
+	publicIP := fmt.Sprintf("172.0.0.%d", utils.RandIntRange(1, 255))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -146,3 +146,7 @@ func CheckThrottling(errCode int, err error) *resource.RetryError {
 	}
 	return resource.NonRetryableError(err)
 }
+
+func RandIntRange(min, max int) int {
+	return min + rand.Intn(max-min)
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -150,3 +150,20 @@ func CheckThrottling(errCode int, err error) *resource.RetryError {
 func RandIntRange(min, max int) int {
 	return min + rand.Intn(max-min)
 }
+
+func RandVpcCidr() string {
+	var result string
+	prefix := RandIntRange(16, 29)
+	switch rand.Intn(3) {
+	case 0:
+		//10.0.0.0 - 10.255.255.255 (10/8 prefix)
+		result = fmt.Sprintf("10.%d.0.0/%d", rand.Intn(256), prefix)
+	case 1:
+		//172.16.0.0 - 172.31.255.255 (172.16/12 prefix)
+		result = fmt.Sprintf("172.%d.0.0/%d", RandIntRange(16, 32), prefix)
+	case 2:
+		//192.168.0.0 - 192.168.255.255 (192.168/16 prefix)
+		result = fmt.Sprintf("192.168.0.0/%d", prefix)
+	}
+	return result
+}


### PR DESCRIPTION
Replace the bugged function "RandIntRange" of terraform.
This function doesn't return the rigth value :
  testacc.RandIntRange(16, 31) return a random int between 0 and (31 - 16)
 
 They fix this in sdk 2.0